### PR TITLE
Quick fix to add osvvm compile support, looks like it is compiling at least

### DIFF
--- a/hdlregression/hdlregression.py
+++ b/hdlregression/hdlregression.py
@@ -817,6 +817,18 @@ class HDLRegression:
         
         return compile_uvvm_all(project=self, path=path_to_uvvm)
 
+    def compile_osvvm(self,
+                      path_to_osvvm: str) -> bool:
+        '''
+        Compiles the entire OSVVM verification library.
+
+        :param path_to_osvvm: the path to where OSVVM is located on HD.
+        :type path_to_osvvm: str
+
+        :rtype: bool
+        :return: True when command is valid
+        '''
+        return compile_osvvm_all(project=self, path=path_to_osvvm)
     def get_args(self):
         '''
         Returns the parsed arguments from HDLRegression

--- a/hdlregression/hdlregression_pkg.py
+++ b/hdlregression/hdlregression_pkg.py
@@ -15,6 +15,7 @@
 
 import platform
 import os
+import re
 import shutil
 from glob import glob
 from multiprocessing.pool import ThreadPool
@@ -517,4 +518,41 @@ def compile_uvvm_all(project, path) -> bool:
                 file_path = os.path.join(script_path, line)
                 project.add_files(os_adjust_path(file_path), library_name=component)
                     
+    return True
+
+def compile_osvvm_all(project, path) -> bool:
+    '''
+    Add files from osvvm.pro script in the order specified there.
+    '''
+    osvvm_path = path
+    if os.path.isdir(osvvm_path) is False:
+        project.logger.error(f'Path to OSVVM is incorrect: {osvvm_path}')
+        return False
+
+    compile_order_file = os.path.join(osvvm_path, 'osvvm.pro')
+    with open(compile_order_file, 'r') as f:
+        lines = f.readlines()
+
+    files = []
+    pattern = r'^\s*analyze\s+([\w.-]+\.\w+)'
+    for line in lines:
+        match = re.search(pattern, line)
+        if match:
+            files.append(os.path.join(path, match.group(1)))
+
+    # in osvvm.pro this is compiled if ToolVendor is Aldec
+    # In osvvm.pro these files are compiled if not ToolSupportGenricPackages, what ever that means.
+    ignore_file_list = ["Aldec", "_c.vhd", "MessagePkg", "generated"]
+    for file in files:
+        ignore = False
+        for ignore_str in ignore_file_list:
+            if ignore_str in file:
+                # print(f"Ignoring file {file}")
+                ignore = True
+                continue
+        if ignore:
+            continue
+        # print(f"Adding file {file}")
+        project.add_files(os_adjust_path(file), library_name="osvvm")
+
     return True


### PR DESCRIPTION
This was a quick fix to add support for osvvm, it compiles osvvm for me at least but not a perfect solution for sure.
And I have not really tested using it.

The if statements in the osvvm.pro file should probably be handled better than how it is done for now with the ignore pattern.

Print comments can/should probably be cleaned up also...
