### PR TITLE
Fix: Add all precompiled libs to modelsim.ini

### DIFF
--- a/hdlregression/hdlregression.py
+++ b/hdlregression/hdlregression.py
@@ -929,7 +929,7 @@ class HDLRegression:
                     self.logger.info(
                         "Setting up precompiled library: %s" % (lib.get_name())
                     )
-                    lib_string = "%s = %s\n" % (
+                    lib_string += "%s = %s\n" % (
                         lib.get_name(),
                         os.path.realpath(lib.get_compile_path()),
                     )


### PR DESCRIPTION
**Issue:**
HDLregression will never write more than one precompiled library to modelsim.ini because it assigns/overwrites `lib_string` with each library instead of appending to the string.

**To reproduce:**
I had two precompiled libraries in my HDLregression-based run.py file like this:

```
hr.add_precompiled_library("C:/Xilinx/vivado_simlib/xpm", "xpm")
hr.add_precompiled_library("C:/Xilinx/vivado_simlib/unisim", "unisim")
```

HDLregression should create a modelsim.ini file when I run the script the first time (or after deleting the hdlregression build directory).

```
$ python run.py

==========================================================================================================================================================================================================================================================================================
  HDLRegression version 0.40.1
  See /doc/hdlregression.pdf for documentation.
==========================================================================================================================================================================================================================================================================================


Scanning files...
Building test suite structure...
Setting up: C://some//path//hdlregression//library\modelsim.ini.
Setting up precompiled library: unisim
Setting up precompiled library: xpm
Compiling library: uvvm_util  - OK -
Compiling library: uvvm_vvc_framework  - OK -
Compiling library: bitvis_vip_scoreboard  - OK -
Compiling library: bitvis_vip_axistream  - OK -
...
```

Both libraries are processed, but the script fails when it tries to compile a VHDL file that requires unisim:

```
** Error: C:/some/path/some_vhdl_file.vhd(33): (vcom-1598) Library "unisim" not found.
** Error: C:/some/path/some_vhdl_file.vhd(34): (vcom-1136) Unknown identifier "unisim".
Error: Program ended with exit code 2
```

If I look at the generated modelsim.ini file under `hdlregression/library` I see only one of the precompiled-libraries were added:

```
[Library]
xpm = C:\Xilinx\vivado_simlib\xpm

others = $MODEL_TECH/../modelsim.ini

; "Normal" libraries such as UVVM follow at this point

```