### PR TITLE
Bugfix: CLI command  -tc <testcase number> 

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,6 +1,6 @@
 HDLRegression authors
 =====================
 
-:Authorts:
+:Authors:
   - EmLogic
   - Inventas

--- a/doc/src/api.rst
+++ b/doc/src/api.rst
@@ -198,7 +198,7 @@ Changes the default library name used when `add_files()`_ is used without the ``
 
 .. code-block:: python
 
-  set_deafult_library(<library_name>)
+  set_default_library(<library_name>)
 
 +-----------------+-----------+---------------+
 | Argument        | Type      | Required      | 

--- a/hdlregression/run/testbuilder.py
+++ b/hdlregression/run/testbuilder.py
@@ -284,7 +284,7 @@ class TestBuilder:
         # Select based on user input as number og testcase name
         if _is_testcase_an_index_number() is True:
             index = _get_testcase_index_number()
-            if index not in range(1, self.test_id_count):
+            if index not in range(1, self.test_id_count + 1):
                 self.logger.error(
                     "Testcase index out of range (1 to %d)." % (self.test_id_count)
                 )


### PR DESCRIPTION
Bugfix for issue #8:
The python range statement range(min,max) produces the range [min, max - 1]. Hence max is not included.