### PR TITLE
Change install description to use the standard preferred python way.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,14 +4,11 @@ HDLRegression FPGA regression test runner
 Getting started
 ---------------
 
-HDLRegression can be installed as a local Python3 package running these two commands in the HDLRegression folder:
+HDLRegression can be installed as a local Python3 package running in developer mode using the following command in the HDLRegression folder:
 
-$ python setup.py build
+$ python -m pip install -e .
 
-$ python setup.py develop
-
-
-Or, used without package installation, but by adding HDLRegression to the Python PATH inside the regression script:
+Or, used without package installation (not recommended), but by adding HDLRegression to the Python PATH inside the regression script:
 
 1. import sys
 2. sys.path.append(<path_to_hdlregression_folder>)

--- a/doc/src/_build/html/intro.html
+++ b/doc/src/_build/html/intro.html
@@ -225,19 +225,8 @@ We recommend that HDLRegression is installed as a Python package as this will ma
 portable and easy to write.
 Execute the two following commands to install HDLRegression as package:</p>
 <ol class="arabic simple">
-<li><p>Build the package</p></li>
-</ol>
-<div class="highlight-console notranslate"><div class="highlight"><pre><span></span><span class="go">python3 setup.py build</span>
-</pre></div>
-</div>
-<ol class="arabic simple" start="2">
-<li><p>Install the HDLRegression package</p></li>
-</ol>
-<div class="highlight-console notranslate"><div class="highlight"><pre><span></span><span class="go">python3 setup.py develop</span>
-</pre></div>
-</div>
-<p>Or use the Python package-management system</p>
-<div class="highlight-console notranslate"><div class="highlight"><pre><span></span><span class="go">pip install .</span>
+<p>Use the Python package-management system in developer mode</p>
+<div class="highlight-console notranslate"><div class="highlight"><pre><span></span><span class="go">pip install -e .</span>
 </pre></div>
 </div>
 <p>HDLRegression can be imported directly in the regression script as any standard Python module</p>

--- a/doc/src/_build/html/intro.html
+++ b/doc/src/_build/html/intro.html
@@ -235,11 +235,7 @@ Execute the two following commands to install HDLRegression as package:</p>
 </div>
 <section id="uninstall">
 <h3>Uninstall<a class="headerlink" href="#uninstall" title="Permalink to this headline"></a></h3>
-<p>Uninstalling can be done with the commands:</p>
-<div class="highlight-console notranslate"><div class="highlight"><pre><span></span><span class="go">python3 setup.py develop --uninstall</span>
-</pre></div>
-</div>
-<p>Or if installed using pip:</p>
+<p>Uninstalling can be done with the command:</p>
 <div class="highlight-console notranslate"><div class="highlight"><pre><span></span><span class="go">pip uninstall hdlregression</span>
 </pre></div>
 </div>

--- a/hdlregression/hdlregression.py
+++ b/hdlregression/hdlregression.py
@@ -1238,7 +1238,7 @@ class HDLRegression:
 
         # Helper method
         def _dump(container, filename):
-            filename = os.path.join(os.getcwd(), "hdlregression", filename)
+            filename = os.path.join(os.getcwd(), "hdlregression_output", filename)
             filename = os_adjust_path(filename)
             dump_file = open(filename, "wb")
             pickle.dump(container, dump_file, pickle.HIGHEST_PROTOCOL)
@@ -1265,7 +1265,7 @@ class HDLRegression:
 
         # Helper method
         def _load(container, filename):
-            filename = os.path.join(os.getcwd(), "hdlregression", filename)
+            filename = os.path.join(os.getcwd(), "hdlregression_output", filename)
             filename = os_adjust_path(filename)
             try:
                 load_file = open(filename, "rb")

--- a/hdlregression/run/runner_aldec.py
+++ b/hdlregression/run/runner_aldec.py
@@ -50,7 +50,7 @@ class AldecRunner(SimRunner):
         Returns:
             return_list(list): a list with simulator command to be used with a subprocess call.
         '''
-        libraries_path = os.path.join(self.project.settings.get_sim_path(), 'hdlregression', 'library')
+        libraries_path = os.path.join(self.project.settings.get_sim_path(), self.project.settings.get_output_path(), 'library')
         compile_path = os.path.join(libraries_path, hdlfile.get_library().get_name())
 
         hdlfile_path = os.path.join(hdlfile.get_filename_with_path())
@@ -97,7 +97,7 @@ class AldecRunner(SimRunner):
         '''
         compile_ok = True
 
-        libraries_path = os.path.join(self.project.settings.get_sim_path(), 'hdlregression', 'library')
+        libraries_path = os.path.join(self.project.settings.get_sim_path(), self.project.settings.get_output_path(), 'library')
         libraries_path = os_adjust_path(libraries_path)
 
         # Define where library compile should be located

--- a/hdlregression/run/runner_ghdl.py
+++ b/hdlregression/run/runner_ghdl.py
@@ -87,7 +87,7 @@ class GHDLRunner(SimRunner):
         hdl_version = self._convert_hdl_version(hdlfile.get_hdl_version())
 
         output_path = os.path.join(
-            self.project.settings.get_sim_path(), "hdlregression", "library"
+            self.project.settings.get_sim_path(), self.project.settings.get_output_path(),"library"
         )
         library_name = hdlfile.get_library().get_name()
         library_compile_path = os.path.join(output_path, library_name)

--- a/hdlregression/run/runner_modelsim.py
+++ b/hdlregression/run/runner_modelsim.py
@@ -43,7 +43,7 @@ class ModelsimRunner(SimRunner):
             modelsim_ini_file(str): full path of modelsim.ini file.
         '''
         if not self._is_simulator('GHDL'):
-            libraries_path = os.path.join(self.project.settings.get_sim_path(), 'hdlregression', 'library')
+            libraries_path = os.path.join(self.project.settings.get_sim_path(), self.project.settings.get_output_path(), 'library')
             libraries_path = os_adjust_path(libraries_path)
 
             modelsim_ini_file = os.path.join(libraries_path, 'modelsim.ini')
@@ -75,7 +75,7 @@ class ModelsimRunner(SimRunner):
         Returns:
             return_list(list): a list with simulator command to be used with a subprocess call.
         '''
-        libraries_path = os.path.join(self.project.settings.get_sim_path(), 'hdlregression', 'library')
+        libraries_path = os.path.join(self.project.settings.get_sim_path(), self.project.settings.get_output_path(), 'library')
         compile_path = os.path.join(libraries_path, hdlfile.get_library().get_name())
 
         hdlfile_path = os.path.join(hdlfile.get_filename_with_path())
@@ -122,7 +122,7 @@ class ModelsimRunner(SimRunner):
         '''
         compile_ok = True
 
-        libraries_path = os.path.join(self.project.settings.get_sim_path(), 'hdlregression', 'library')
+        libraries_path = os.path.join(self.project.settings.get_sim_path(), self.project.settings.get_output_path(), 'library')
         libraries_path = os_adjust_path(libraries_path)
 
         # Define where library compile should be located
@@ -178,7 +178,7 @@ class ModelsimRunner(SimRunner):
         Called from: _get_simulator_call()
         '''
         modelsim_ini = os.path.join(self.project.settings.get_sim_path(),
-                                    'hdlregression',
+                                    self.project.settings.get_output_path(),
                                     'library',
                                     'modelsim.ini')
         return os_adjust_path(modelsim_ini)

--- a/hdlregression/run/runner_nvc.py
+++ b/hdlregression/run/runner_nvc.py
@@ -77,7 +77,7 @@ class NVCRunner(SimRunner):
         hdl_version = self._convert_hdl_version(hdlfile.get_hdl_version())
 
         output_path = os.path.join(
-            self.project.settings.get_sim_path(), "hdlregression", "library"
+            self.project.settings.get_sim_path(), self.project.setting.get_output_path(), "library"
         )
         library_name = hdlfile.get_library().get_name()
         library_compile_path = os.path.join(output_path, library_name)

--- a/hdlregression/run/runner_riviera.py
+++ b/hdlregression/run/runner_riviera.py
@@ -50,7 +50,7 @@ class RivieraRunner(SimRunner):
         Returns:
             return_list(list): a list with simulator command to be used with a subprocess call.
         '''
-        libraries_path = os.path.join(self.project.settings.get_sim_path(), 'hdlregression', 'library')
+        libraries_path = os.path.join(self.project.settings.get_sim_path(), self.project.settings.get_output_path(), 'library')
         compile_path = os.path.join(libraries_path, hdlfile.get_library().get_name())
 
         hdlfile_path = os.path.join(hdlfile.get_filename_with_path())
@@ -97,7 +97,7 @@ class RivieraRunner(SimRunner):
         '''
         compile_ok = True
 
-        libraries_path = os.path.join(self.project.settings.get_sim_path(), 'hdlregression', 'library')
+        libraries_path = os.path.join(self.project.settings.get_sim_path(), self.project.settings.get_output_path(), 'library')
         libraries_path = os_adjust_path(libraries_path)
 
         # Define where library compile should be located

--- a/hdlregression/run/vivado_runner.py
+++ b/hdlregression/run/vivado_runner.py
@@ -39,7 +39,7 @@ class VivadoRunner(SimRunner):
         return (simulator.upper() == cls.SIMULATOR_NAME)
 
     def _get_compile_call(self, hdlfile) -> list:
-        libraries_path = os.path.join(self.project.settings.get_sim_path(), 'hdlregression', 'library')
+        libraries_path = os.path.join(self.project.settings.get_sim_path(), self.project.settings.get_output_path(), 'library')
         compile_path = os.path.join(libraries_path, hdlfile.get_library().get_name())
         hdlfile_path = os.path.join(hdlfile.get_filename_with_path())
 
@@ -71,7 +71,7 @@ class VivadoRunner(SimRunner):
 
     def _compile_library(self, library, force_compile=False) -> 'HDLLibrary':
         compile_ok = True
-        libraries_path = os.path.join(self.project.settings.get_sim_path(), 'hdlregression', 'library')
+        libraries_path = os.path.join(self.project.settings.get_sim_path(), self.project.settings.get_output_path(), 'library')
         libraries_path = os_adjust_path(libraries_path)
 
         # Library compile path

--- a/hdlregression/settings.py
+++ b/hdlregression/settings.py
@@ -59,7 +59,7 @@ class HDLRegressionSettings:
         self.sim_path = None
         self.src_path = None
         self.script_path = None
-        self.output_path = "./hdlregression"
+        self.output_path = "./hdlregression_output"
 
         self.library_compile_list = []
         self.library_name = "my_work_lib"


### PR DESCRIPTION
pip install -e . will install the package in editable mode so it can be modified but it is handled by the pip python package management system.

setup.py as a command line tool are deprecated.
https://packaging.python.org/en/latest/discussions/setup-py-deprecated/