### PR TITLE
Yield cmd_runner thread when nothing to do to limit CPU usage

### DIFF
--- a/hdlregression/run/cmd_runner.py
+++ b/hdlregression/run/cmd_runner.py
@@ -15,6 +15,7 @@
 
 import subprocess
 import os
+import time
 import sys
 from threading import Thread
 from queue import Queue, Empty
@@ -125,6 +126,8 @@ class CommandRunner:
                             break
 
                 if transcript_line is None:
+                    # Yield thread when there's no line to process to limit CPU usage
+                    time.sleep(0.05)
                     return_code = popen.poll()
                     if return_code is not None:
                         # Subprocess finished, wait for the threads to complete


### PR DESCRIPTION
I noticed the `run` function in `cmd_runner.py` constantly checks the transcript queue and polls the simulation process to check if it's still running. The python thread basically never yields and has 100% CPU usage. Adding a short `sleep()` call when there is no transcript line to process allows the run thread to yield when there's nothing to do and reduces CPU usage significantly.
(I thought maybe there's a more elegant way to yield than using sleep, but it seems like that's actually what people use: https://stackoverflow.com/a/790246).

You can easily see the difference in `top` etc. in Linux, but I also tested and profiled this in this branch/repo: https://github.com/svnesbo/axistream_uart/tree/hdlregression_profiling_test
That branch has a HDLregression + UVVM testbench with 16x identical test cases. Each TC takes around 30-40s to run on my system. And the `run.py` script was setup to use the [Yappi](https://pypi.org/project/yappi/) profiler (which is supposed to support multithreading in Python).

Running 1 TC without yield (sleep) in cmd_runner - around 30s CPU time for the Python thread (sim takes around 30s as well):
![profiling_1_thread_1_testcase_without_cmd_runner_yield](https://github.com/user-attachments/assets/b607044e-09fe-4de7-a07f-44a5d14a0519)

Running 1 TC **with** yield in cmd_runner has much lower CPU time for the Python thread:
![profiling_1_thread_1_testcase_with_cmd_runner_yield](https://github.com/user-attachments/assets/5019a712-d071-42d8-a305-20420c4f3c53)

That testbench/case has a lot of log activity though (probably much more than you'd normally want), so the run thread actually has quite a lot of work to do. If I disable all the VVC output logs then the CPU time basically reduces to nothing when the line to yield is there (if I run that without the yield though then the results are more or less unchanged, but I chose to not include a picture of that):
![profiling_1_thread_1_testcase_with_cmd_runner_yield_and_no_VVC_log](https://github.com/user-attachments/assets/ba88c5c9-3e7b-43a8-85db-09fce9fa3ccd)

If I'm only running 1 TC (one thread) then the simulation takes 30s regardless of yield in cmd_runner, since there's plenty of CPU cores it doesn't matter if some CPU time is wasted. But if I run the full regression using 8 threads (my system has 8 CPU cores), so each thread gets to run 2 of the 16 TCs then there is a difference. Basically, it takes around 1m:17s for the full simulation with the yield, and around 1m:30s without it (that's fairly consistent if I run it again). So that's a speedup of about 15% when I try to utilize all cores on my system.