### PR TITLE
Fix --no_sim return code issue due to overwriting of settings

### DIFF
--- a/hdlregression/hdlregression.py
+++ b/hdlregression/hdlregression.py
@@ -42,6 +42,7 @@ from .run.runner_aldec import AldecRunner
 from .construct.hdllibrary import HDLLibrary, PrecompiledLibrary
 from .configurator import SettingsConfigurator
 from .run.hdltests import TestStatus
+import copy
 import sys
 import os
 import pickle
@@ -1238,29 +1239,30 @@ class HDLRegression:
             pickle.dump(container, dump_file, pickle.HIGHEST_PROTOCOL)
             dump_file.close()
 
-        simulator_settings = self.settings.get_simulator_settings()
+        settings_copy = copy.deepcopy(self.settings)
+        simulator_settings = settings_copy.get_simulator_settings()
         if reset:
             # Do not save argument settings, i.e. this will make next run
             # behave as selected with previous run arguments.
-            self.settings = self.settings_config.unset_argument_settings(self.settings)
+            settings_copy = self.settings_config.unset_argument_settings(settings_copy)
 
-        _dump(self.library_container, "library.dat", self.settings.get_output_path())
-        _dump(self.generic_container, "generic.dat", self.settings.get_output_path())
+        _dump(self.library_container, "library.dat", settings_copy.get_output_path())
+        _dump(self.generic_container, "generic.dat", settings_copy.get_output_path())
         _dump(
-            self.testgroup_container, "testgroup.dat", self.settings.get_output_path()
+            self.testgroup_container, "testgroup.dat", settings_copy.get_output_path()
         )
         _dump(
             self.testgroup_collection_container,
             "testgroup_collection.dat",
-            self.settings.get_output_path(),
+            settings_copy.get_output_path(),
         )
-        _dump(self.settings, "settings.dat", self.settings.get_output_path())
+        _dump(settings_copy, "settings.dat", settings_copy.get_output_path())
         _dump(
             self.runner.get_re_run_test_obj_list(),
             "testcase.dat",
-            self.settings.get_output_path(),
+            settings_copy.get_output_path(),
         )
-        _dump(simulator_settings, "simulator.dat", self.settings.get_output_path())
+        _dump(simulator_settings, "simulator.dat", settings_copy.get_output_path())
 
     def _load_project_from_disk(self, output_path: str) -> None:
         """


### PR DESCRIPTION
HDLregression returns -1 when run with `--no_sim`. Tested with this command for a HDLregression based run.py script:
```
run.py --no_sim -s nvc -v
```

The reason is that `self.settings.get_no_sim()` returns False on [line 635](https://github.com/HDLUtils/hdlregression/blob/bfea3893bff9ff193a37b3d7aca69638803a3baf/hdlregression/hdlregression.py#L635), because it has been reset earlier by the call to `self._save_project_to_disk(reset=True)` on line 629.

This PR changes `_save_project_to_disk` to work on a copy of the settings leaving the original settings unchanged. I don't know if this can cause any other issues though, but it fixes my problem.