### PR TITLE
Export Testcase Information as JSON: CLI argument -etj, --exportTestcaseJson

### DIFF
--- a/hdlregression/arg_parser.py
+++ b/hdlregression/arg_parser.py
@@ -72,6 +72,9 @@ def arg_parser_reader(arg_parser=None):
             "-ltc", "--listTestcase", action="store_true", help="list testcases"
         )
         arg_parser.add_argument(
+            "-etj", "--exportTestcaseJson", action="store", type=str, nargs=1, help="export testcases to JSON file with the given path. Example: --exportTestcaseJson testcases.json"
+        )
+        arg_parser.add_argument(
             "-ltg", "--listTestgroup", action="store_true", help="list testgroups"
         )
         arg_parser.add_argument(
@@ -170,6 +173,9 @@ def arg_parser_update_settings(settings, args) -> "HDLRegressionSettings":
     settings.set_list_compile_order(args.listCompileOrder)
     settings.set_list_testgroup(args.listTestgroup)
     settings.set_force_recompile(args.forceCompile)
+
+    if args.exportTestcaseJson:
+        settings.set_export_testcases_json_path(args.exportTestcaseJson[0])
 
     if args.threading:
         settings.set_threading(True)

--- a/hdlregression/configurator.py
+++ b/hdlregression/configurator.py
@@ -47,6 +47,7 @@ class SettingsConfigurator:
         settings.set_testcase(default_settings.get_testcase())
         settings.set_testgroup(default_settings.get_testgroup())
         settings.set_list_testcase(default_settings.get_list_testcase())
+        settings.set_export_testcases_json_path(default_settings.get_export_testcases_json_path())
         settings.set_list_compile_order(default_settings.get_list_compile_order())
         settings.set_list_testgroup(default_settings.get_list_testgroup())
         settings.set_stop_on_failure(default_settings.get_stop_on_failure())

--- a/hdlregression/hdlregression.py
+++ b/hdlregression/hdlregression.py
@@ -531,6 +531,9 @@ class HDLRegression:
         if self.settings.get_list_testcase():
             print(list_testcases(self.runner))
 
+        elif self.settings.get_export_testcases_json_path():
+            print(export_testcases_to_json(self.runner,self.settings.get_export_testcases_json_path()))
+
         elif self.settings.get_list_dependencies():
             for library in self.library_container.get():
                 print(library._present_library())

--- a/hdlregression/hdlregression_pkg.py
+++ b/hdlregression/hdlregression_pkg.py
@@ -17,6 +17,7 @@ import platform
 import os
 import re
 import shutil
+import json
 import subprocess
 from glob import glob
 from multiprocessing.pool import ThreadPool
@@ -134,6 +135,40 @@ def list_testcases(runner) -> str:
 
     return "\n".join(tc_lines)
 
+def export_testcases_to_json(runner, filename) -> str:
+    """
+    Export testcases to a JSON file.
+
+    :param runner: The test runner object.
+    :param filename: The name of the output JSON file.
+    """
+    runner.testbuilder.build_tb_module_list()
+    runner.testbuilder._build_base_tests()
+    run_tests = runner.testbuilder.get_list_of_tests_to_run()
+
+    tests = []
+    for test in run_tests:
+        language = "VHDL" if test.get_is_vhdl() else "VERILOG" if test.get_is_verilog() else "UNKNOWN"
+
+        testcase_info = {
+            "testcase_id": test.get_id_number(),
+            "testcase_name": test.get_testcase_name(),
+            "name": test.get_name(),
+            "architecture": test.get_arch().get_name() if language is test.get_is_vhdl() else "",
+            "testcase": test.get_tc(),
+            "generics": test.get_gc(),
+            "hdl_file_name": test.get_hdlfile().get_name(),
+            "hdl_file_path" : test.get_hdlfile().get_filename_with_path(),
+            "hdl_file_lib":test.get_hdlfile().get_library().get_name(),
+            "language": language,
+        }
+        tests.append(testcase_info)
+
+    with open(filename, "w") as json_file:
+        json.dump(tests, json_file, indent=4)
+
+    return f"Testcases exported to {filename}"
+                
 
 # ========================================================
 #

--- a/hdlregression/hdlregression_pkg.py
+++ b/hdlregression/hdlregression_pkg.py
@@ -150,13 +150,19 @@ def export_testcases_to_json(runner, filename) -> str:
     for test in run_tests:
         language = "VHDL" if test.get_is_vhdl() else "VERILOG" if test.get_is_verilog() else "UNKNOWN"
 
+        # generics are internally stored as list where odd elements are names and even elements are values
+        # convert to dict for easier access
+        generics = test.get_gc()
+        if generics:
+            generics = dict(zip(generics[::2], generics[1::2]))
+
         testcase_info = {
             "testcase_id": test.get_id_number(),
             "testcase_name": test.get_testcase_name(),
             "name": test.get_name(),
             "architecture": test.get_arch().get_name() if language is test.get_is_vhdl() else "",
             "testcase": test.get_tc(),
-            "generics": test.get_gc(),
+            "generics": generics,
             "hdl_file_name": test.get_hdlfile().get_name(),
             "hdl_file_path" : test.get_hdlfile().get_filename_with_path(),
             "hdl_file_lib":test.get_hdlfile().get_library().get_name(),

--- a/hdlregression/settings.py
+++ b/hdlregression/settings.py
@@ -83,6 +83,7 @@ class HDLRegressionSettings:
         self.wlf_dunmp_enable = False
 
         self.list_testcase = False
+        self.export_testcases_json_path = None
         self.list_compile_order = False
         self.list_testgroup = False
         self.list_dependencies = False
@@ -390,6 +391,13 @@ class HDLRegressionSettings:
 
     def get_list_testcase(self) -> bool:
         return self.list_testcase
+    
+    def get_export_testcases_json_path(self) -> str:
+        return self.export_testcases_json_path
+    
+    def set_export_testcases_json_path(self, json_path):
+        if isinstance(json_path, str):
+            self.export_testcases_json_path = json_path.lower()
 
     def set_testcase(self, testcase):
         """


### PR DESCRIPTION
This PR adds the CLI argument -etj, --exportTestcaseJson PATH. 

The command writes detailed information about the available test cases to the given JSON file without running the tests. 

The feature will close https://github.com/HDLUtils/hdlregression/issues/10 and https://github.com/HDLUtils/hdlregression/issues/12. 

Example: 

`python hr.py -etj testcases.json`


```
[
    {
        "testcase_id": 1,
        "testcase_name": "irqc_demo_tb.func",
        "name": "irqc_demo_tb",
        "architecture": "",
        "testcase": null,
        "generics": null,
        "hdl_file_name": "irqc_demo_tb",
        "hdl_file_path": "C:\\P2L2\\HDLRegression\\UVVM\\bitvis_irqc\\tb\\irqc_demo_tb.vhd",
        "hdl_file_lib": "bitvis_irqc",
        "language": "VHDL"
    },
    {
        "testcase_id": 2,
        "testcase_name": "tb_generics.test",
        "name": "tb_generics",
        "architecture": "",
        "testcase": null,
        "generics": {
            "GC_GENERIC_1": 10,
            "GC_GENERIC_2": 20,
            "GC_TESTCASE": "testcase_1"
        },
        "hdl_file_name": "tb_generics",
        "hdl_file_path": "C:\\P2L2\\HDLRegression\\hdlregression\\test\\tb\\tb_generics.vhd",
        "hdl_file_lib": "test_2_lib",
        "language": "VHDL"
    }
]
```


This feature will ease the implementation of 3rd party applications that need to run specific test cases. 
For example, the HDL-Regression VS-Code Extension [HDLRegressionByHGB](https://github.com/HSD-ESD/HDLRegression-by-HGB). 
Currently, the extension extracts this kind of information from the command line output, which is hacky and involves maintenance whenever the output changes (see https://github.com/HSD-ESD/HDLRegression-by-HGB/issues/4). 


 