### PR TITLE
Fix: Allow HDLRegression to detect configuration instantiations with generic/port maps

### DIFF
--- a/hdlregression/scan/hdl_regex_pkg.py
+++ b/hdlregression/scan/hdl_regex_pkg.py
@@ -86,8 +86,17 @@ RE_VHDL_ENTITY = re.compile(ID_VHDL_ENTITY, flags=re.IGNORECASE)
 ID_VHDL_ENTITY_DECLARATION = r"[\s+]?entity\s+.*\s+[\s\r\n]?is"
 RE_VHDL_ENTITY_DECLARATION = re.compile(ID_VHDL_ENTITY_DECLARATION, flags=re.IGNORECASE)
 
-ID_VHDL_CONFIGURATION_INSTANTIATION = r"\s+.*:\s+configuration\s+\w+"
-RE_VHDL_CONFIGURATION_INSTANTIATION = re.compile(ID_VHDL_CONFIGURATION_INSTANTIATION, flags=re.IGNORECASE)
+ID_VHDL_CONFIGURATION_INSTANTIATION = (
+    r"\b\w+\s*:\s*configuration"       # label and 'configuration' keyword
+    r"\s+[a-zA-Z0-9_.]+"               # configuration name with optional lib.
+    r"(?:\s+generic\s+map\s*\(.*?\))?" # optional generic map
+    r"(?:\s+port\s+map\s*\(.*?\))?"    # optional port map
+    r"\s*;"                            # terminating semicolon
+)
+RE_VHDL_CONFIGURATION_INSTANTIATION = re.compile(
+    ID_VHDL_CONFIGURATION_INSTANTIATION,
+    flags=re.IGNORECASE | re.DOTALL | re.VERBOSE
+)
 
 ID_VHDL_CONFIGURATION_DECLARATION = r"[\s+]?configuration\s+.*\s+[\s\r\n]?of\s+.*\s+is"
 RE_VHDL_CONFIGURATION_DECLARATION = re.compile(ID_VHDL_CONFIGURATION_DECLARATION, flags=re.IGNORECASE)

--- a/hdlregression/scan/vhdlscanner.py
+++ b/hdlregression/scan/vhdlscanner.py
@@ -682,11 +682,13 @@ class ArchitectureParser(BaseParser):
     def _configuration_instantiation(self, code):
         # Configuration instantiations
         re_configuration = re.compile(r'''
-            \b\w+
-            \s*\:\s*configuration
-            \s+(?P<name>[a-zA-Z_0-9\.]+)
-            \s*;
-        ''', flags=self._ALL_FLAGS)
+            \b\w+                          # label
+            \s*:\s*configuration
+            \s+(?P<name>[a-zA-Z_0-9\.]+)  # configuration name (with optional lib.)
+            (?:\s+generic\s+map\s*\(.*?\))? # optional generic map
+            (?:\s+port\s+map\s*\(.*?\))?    # optional port map
+            \s*;                           # semicolon
+        ''', flags=self._ALL_FLAGS | re.DOTALL | re.VERBOSE)
         for match in re.finditer(re_configuration, code):
             conf_name = match.group('name')
 


### PR DESCRIPTION
This PR extends HDLRegression’s configuration-instantiation detection to support  VHDL constructs such as:
```vhdl
inst : configuration work.my_cfg
    generic map (
        ...
    )
    port map (
        ...
    );
```


Changes include:
  1. Expanded regex in hdl_regex_pkg.py 
  2. Updated _configuration_instantiation() in vhdlscanner.py